### PR TITLE
feat/getClientes

### DIFF
--- a/src/controladores/cliente/listar.js
+++ b/src/controladores/cliente/listar.js
@@ -1,0 +1,17 @@
+const listagens = require('../../servicos/repositorios/clientes/listagemCliente');
+
+const listarClientes = async (req, res) => {
+    const { id } = req.params;
+
+    try {
+
+        const listagemDeClientes =  await listagens(id);
+
+        return res.status(listagemDeClientes.status).json(listagemDeClientes.resposta);
+
+    } catch (error) {
+        return res.status(500).json(error.message);
+    };
+};
+
+module.exports = listarClientes;

--- a/src/rotas.js
+++ b/src/rotas.js
@@ -20,6 +20,7 @@ const postCliente = require("./controladores/cliente/cadastrar");
 const putCliente = require("./controladores/cliente/atualizar");
 const listaProdutos = require("./controladores/produtos/listar");
 const excluiProduto = require("./controladores/produtos/excluir");
+const listarClientes = require("./controladores/cliente/listar");
 const rotas = express();
 
 rotas.get("/categoria", getCategorias);
@@ -37,5 +38,7 @@ rotas.get('/produto/:id', listaProdutos)
 rotas.delete('/produto/:id', excluiProduto)
 rotas.post('/cliente', validarCorpoRequisicao(schemaCliente), postCliente);
 rotas.put('/cliente/:id', validarCorpoRequisicao(schemaCliente), putCliente);
+rotas.get(['/cliente', '/cliente/:id'], listarClientes);
+
 
 module.exports = rotas;

--- a/src/servicos/repositorios/clientes/listagemCliente.js
+++ b/src/servicos/repositorios/clientes/listagemCliente.js
@@ -1,0 +1,32 @@
+const knex = require('../../bancoDeDados/conexao');
+const { clienteValido, clienteInvalido, clientesSemCadastro } = require("../../../utilitarios/mensagens");
+const { consultarClientes } = require("./consultasClientes");
+
+const listagens = async (id) => {
+
+    try {
+        if (id) {
+
+            const clienteExistente = await consultarClientes({ id });
+
+            if (clienteExistente.length < 1) return clienteInvalido;
+
+            clienteValido.resposta = clienteExistente;
+
+            return clienteValido;
+
+        } else {
+            const clientesExistentes = await knex('*').from('clientes');
+
+            if (clientesExistentes.length < 1) return clientesSemCadastro;
+
+            clienteValido.resposta = clientesExistentes;
+
+            return clienteValido;
+        };
+    } catch (error) {
+        return error.message;
+    };
+};
+
+module.exports = listagens;

--- a/src/servicos/repositorios/emailExistente.js
+++ b/src/servicos/repositorios/emailExistente.js
@@ -1,9 +1,13 @@
 const knex = require('../../servicos/bancoDeDados/conexao');
 
 async function emailExistente(email){
-    const resultado = await knex("usuarios").where({ email }).first();
+    try {
+        const resultado = await knex("usuarios").where({ email }).first();
 
-    return resultado
+        return resultado;
+    } catch (error) {
+        return error.message;
+    };
 }
 
 module.exports = emailExistente;

--- a/src/utilitarios/mensagens.js
+++ b/src/utilitarios/mensagens.js
@@ -68,6 +68,11 @@ const clienteInvalido = {
     resposta: 'Cliente não encontrado.'
 }
 
+const clientesSemCadastro = {
+    status: 404,
+    resposta: 'Não existem clientes cadastrados.'
+};
+
 const clienteJaCadastrado = {
     status: 404,
     resposta: 'Cliente já cadastrado.'
@@ -114,5 +119,6 @@ module.exports = {
     campoObrigatorio,
     formatoCepInvalido,
     formatoCpfInvalido,
-    formatoEmailInvalido
+    formatoEmailInvalido,
+    clientesSemCadastro
 }


### PR DESCRIPTION
Criação da rota get clientes, para listagem de clientes com ou sem o id informado no parâmetro da url. 
Criação do controlador **listar.js** dentro da pasta clientes.
Criação do repositorios/clientes/+ -> listagemClientes.js que é usada dentro do controlador de **listar.js**. 
Coloquei trycatch no repositório de emailExistente.js pelo mesmo usar promise para ter um retorno.
Criação de uma mensagem de retorno na utilitarios/mensagem.js -> +clientesSemCadastro.